### PR TITLE
New classification of possible mismatch types

### DIFF
--- a/src/net/ssehub/kernel_haven/config_mismatches/MismatchResultType.java
+++ b/src/net/ssehub/kernel_haven/config_mismatches/MismatchResultType.java
@@ -20,16 +20,37 @@ import net.ssehub.kernel_haven.util.null_checks.NonNull;
 /**
  * Categorizes the results of the {@link ConfigMismatchDetector}.
  * @author El-Sharkawy
+ * @author Slawomir Duszynski
  *
  */
 public enum MismatchResultType {
-
-    CONSISTENT("Consistent"),
-    CONFLICT_WITH_VARMODEL("Conflicts with VarModel"),
+	/*
+	 * M - Feature Model
+	 * E - Feature Effect
+	 * 
+	 * the comments below describe the satisfiability for 3 cases:
+	 * SAT (M && -E)  ;   SAT (M && E) ;  SAT (-M && E)   
+	 */
+    CONSISTENT("Consistent"), 										// FALSE TRUE FALSE
+    CONTRADICTION("Contradicts with VarModel"), 					// TRUE FALSE TRUE
+    VM_MORE_GENERAL("VarModel is more general than the formula"),	//TRUE TRUE FALSE
+    FORMULA_MORE_GENERAL("Formula is more general than the VarModel"),//FALSE TRUE TRUE
+    PARTIAL_OVERLAP("VarModel and formula partially overlap"),		//TRUE TRUE TRUE
+    PARTIAL_OVERLAP_DEAD("VarModel and formula partially overlap, but only if the feature is false"), //TRUE TRUE TRUE, + additional check for this case
     VARIABLE_NOT_DEFINED("Variable not defined in VarModel"),
     FORMULA_NOT_SUPPORTED("Formula contains undefined Variables"),
     ERROR("Unexpected error occured.");
-    
+	/*
+	 * Assuming that:
+	 * - the features in the feature model were not dead or always-selected
+	 * - the feature effect of a feature cannot be FALSE  
+	 * There are then no more possible cases. Especially:
+	 * - there is no PARTIAL_OVERLAP_ALWAYS_SELECTED. As we only consider the feature effect of the current feature F, 
+	 * 		and it has the form of F => Other, there is no possibility to prevent F from being set to false. 
+	 * - the dead feature case can only happen for PARTIAL_OVERLAP. This is because in the other cases M or E are entirely within the set intersection, 
+	 * 		and they (per assumption) do not contain dead or always-selected features. 
+	 */
+	
     private @NonNull String description;
     
     /**

--- a/testdata/AConflictsB.cnf
+++ b/testdata/AConflictsB.cnf
@@ -1,0 +1,5 @@
+c 1 ALPHA
+c 2 BETA
+c 3 GAMMA
+p cnf 3 1
+-1 -2 0

--- a/testdata/AEqualsB.cnf
+++ b/testdata/AEqualsB.cnf
@@ -1,0 +1,6 @@
+c 1 ALPHA
+c 2 BETA
+c 3 GAMMA
+p cnf 3 2
+-1 2 0
+1 -2 0

--- a/testdata/NotAAndB.cnf
+++ b/testdata/NotAAndB.cnf
@@ -1,0 +1,6 @@
+c 1 ALPHA
+c 2 BETA
+c 3 GAMMA
+p cnf 3 2
+-1 0
+2 0


### PR DESCRIPTION
The classification of possible mismatch types was extended to include all possible cases. The cases are independent of the analysis goal: depending on that analysis goal, only some of the mismatch types might be relevant for the specific case.